### PR TITLE
Add initial tests for Fractal Bitcoin utilities

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,0 +1,78 @@
+import pytest
+from fractal.utils.encoding import (
+    hex_to_bytes, bytes_to_hex, encode_varint, decode_varint,
+    encode_base58, decode_base58, encode_base58_check, decode_base58_check,
+    encode_bech32, decode_bech32, encode_bech32m, decode_bech32m,
+    encode_address, decode_address
+)
+from fractal.constants import Network
+
+
+def test_hex_bytes_roundtrip():
+    data = b"\x00\x01deadbeef"
+    hex_str = bytes_to_hex(data, prefix=True)
+    assert hex_str.startswith("0x")
+    assert hex_to_bytes(hex_str) == data
+    with pytest.raises(Exception):
+        hex_to_bytes("zzzz")
+
+
+def test_varint_roundtrip():
+    for value in [0, 1, 252, 253, 65535, 65536, 2**32 + 1]:
+        encoded = encode_varint(value)
+        decoded, offset = decode_varint(encoded)
+        assert decoded == value
+        assert offset == len(encoded)
+
+
+def test_base58_roundtrip():
+    payload = b"hello world"
+    encoded = encode_base58(payload)
+    assert decode_base58(encoded) == payload
+
+
+def test_base58check_roundtrip():
+    payload = b"test payload"
+    enc = encode_base58_check(payload)
+    dec = decode_base58_check(enc)
+    assert dec == payload
+    with pytest.raises(Exception):
+        decode_base58_check(enc[:-1] + "1")
+
+
+def test_bech32_and_bech32m_roundtrip():
+    hrp = "bc"
+    witprog = b"\x01" * 20
+    addr = encode_bech32(hrp, 0, witprog)
+    assert decode_bech32(addr) == (hrp, 0, witprog)
+
+    hrp_m = "bc"
+    prog_m = b"\x02" * 32
+    addr_m = encode_bech32m(hrp_m, 1, prog_m)
+    assert decode_bech32m(addr_m) == (hrp_m, 1, prog_m)
+
+
+def test_encode_decode_address():
+    hash20 = bytes.fromhex("11" * 20)
+    hash32 = bytes.fromhex("22" * 32)
+
+    addr_p2pkh = encode_address("p2pkh", hash20, Network.MAINNET)
+    t, h = decode_address(addr_p2pkh, Network.MAINNET)
+    assert t == "p2pkh" and h == hash20
+
+    addr_p2sh = encode_address("p2sh", hash20, Network.MAINNET)
+    t, h = decode_address(addr_p2sh, Network.MAINNET)
+    assert t == "p2sh" and h == hash20
+
+    addr_p2wpkh = encode_address("p2wpkh", hash20, Network.MAINNET)
+    t, h = decode_address(addr_p2wpkh, Network.MAINNET)
+    assert t == "p2wpkh" and h == hash20
+
+    addr_p2wsh = encode_address("p2wsh", hash32, Network.MAINNET)
+    t, h = decode_address(addr_p2wsh, Network.MAINNET)
+    assert t == "p2wsh" and h == hash32
+
+    addr_p2tr = encode_address("p2tr", hash32, Network.MAINNET)
+    t, h = decode_address(addr_p2tr, Network.MAINNET)
+    assert t == "p2tr" and h == hash32
+

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,0 +1,31 @@
+from fractal.crypto.keys import PrivateKey, PublicKey
+from fractal.crypto.signature import sign_message, parse_der_signature, encode_der_signature
+from fractal.constants import Network
+
+
+def test_private_key_wif_roundtrip():
+    key = PrivateKey.from_seed(b"seed")
+    wif = key.wif(Network.TESTNET, compressed=True)
+    imported, compressed, net = PrivateKey.from_wif(wif)
+    assert compressed is True
+    assert net == Network.TESTNET
+    assert imported == key
+
+
+def test_public_key_addresses():
+    key = PrivateKey.from_seed(b"seed")
+    pub = key.public_key(compressed=True)
+    assert pub.p2pkh_address(Network.TESTNET).startswith("m") or pub.p2pkh_address(Network.TESTNET).startswith("n")
+    assert pub.p2wpkh_address(Network.TESTNET).startswith("tb1q")
+    assert pub.p2tr_address(Network.TESTNET).startswith("tb1p")
+
+
+def test_der_signature_roundtrip():
+    r = 1
+    s = 2
+    sig = encode_der_signature(r, s)
+    parsed_r, parsed_s, sighash = parse_der_signature(sig)
+    assert parsed_r == r
+    assert parsed_s == s
+    assert sighash is None
+

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,32 @@
+import pytest
+from decimal import Decimal
+
+from fractal.utils import validation as v
+from fractal.constants import Network
+from fractal.utils.encoding import encode_address
+
+
+def test_address_validation():
+    h = bytes.fromhex("11" * 20)
+    addr = encode_address("p2wpkh", h, Network.MAINNET)
+    assert v.is_valid_address(addr, Network.MAINNET)
+    assert v.validate_address(addr, Network.MAINNET) == addr
+    with pytest.raises(v.ValidationError):
+        v.validate_address("invalid")
+
+
+def test_txid_validation():
+    txid = "a" * 64
+    assert v.is_valid_txid(txid)
+    assert v.validate_txid(txid) == txid
+    with pytest.raises(v.ValidationError):
+        v.validate_txid("xyz")
+
+
+def test_amount_conversion():
+    assert v.to_satoshi(1) == 1
+    assert v.to_satoshi(Decimal("1.0")) == 100000000
+    assert v.to_btc(100000000) == Decimal("1")
+    assert v.is_dust_amount(100) is True
+    assert v.is_dust_amount(1000) is False
+


### PR DESCRIPTION
## Summary
- add pytest configuration and tests for encoding utilities
- test validation helpers
- test key and signature helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684496abe444832c92aa950cc0d31c7e